### PR TITLE
SMRT-000 fixing bug in deep_merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This library defines helper functions that are used across SmartCity modules.
 ```elixir
 def deps do
   [
-    {:smart_city, "~> 2.1.2"}
+    {:smart_city, "~> 2.1.3"}
   ]
 end
 ```

--- a/lib/smart_city/helpers.ex
+++ b/lib/smart_city/helpers.ex
@@ -41,6 +41,7 @@ defmodule SmartCity.Helpers do
   Merges two maps into one, including sub maps. Matching keys from the right map will override their corresponding key in the left map.
   """
   @spec deep_merge(map(), map()) :: map()
+  def deep_merge(%{} = left, %{} = right) when right == %{}, do: right
   def deep_merge(left, right), do: Map.merge(left, right, &deep_resolve/3)
 
   defp deep_resolve(_key, %{} = left, %{} = right), do: deep_merge(left, right)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.MixProject do
   def project do
     [
       app: :smart_city,
-      version: "2.1.2",
+      version: "2.1.3",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/smart_city/helpers_test.exs
+++ b/test/smart_city/helpers_test.exs
@@ -57,5 +57,12 @@ defmodule SmartCity.HelpersTest do
 
       assert Helpers.deep_merge(left, right) == %{stuff: %{one: "one", two: 2, stuff: %{one: 1, two: "two"}}}
     end
+
+    test "overrides default map with overrride map when override is empty" do
+      left = Map.new(%{stuff: %{one: 1, two: 2, stuff: %{one: 1, two: 2}}})
+      right = %{}
+
+      assert Helpers.deep_merge(left, right) == %{}
+    end
   end
 end


### PR DESCRIPTION
Allow overriding default map value with empty map
when desired.

co-authored-by: Paul Linville <plinville@pillartechnology.com>
co-authored-by: jeffgrunewald <jeff@grunewalddesign.com>