### PR TITLE
Recognizing upper-cased sourceFormat input types

### DIFF
--- a/lib/smart_city/helpers.ex
+++ b/lib/smart_city/helpers.ex
@@ -46,9 +46,13 @@ defmodule SmartCity.Helpers do
   """
   @spec mime_type(file_type()) :: mime_type()
   def mime_type(file_type) do
-    case MIME.valid?(file_type) do
+    downcased_type = String.downcase(file_type)
+
+    downcased_type
+    |> MIME.valid?()
+    |> case do
       true -> file_type
-      false -> MIME.type(file_type)
+      false -> MIME.type(downcased_type)
     end
   end
 

--- a/lib/smart_city/helpers.ex
+++ b/lib/smart_city/helpers.ex
@@ -48,10 +48,8 @@ defmodule SmartCity.Helpers do
   def mime_type(file_type) do
     downcased_type = String.downcase(file_type)
 
-    downcased_type
-    |> MIME.valid?()
-    |> case do
-      true -> file_type
+    case MIME.valid?(downcased_type) do
+      true -> downcased_type
       false -> MIME.type(downcased_type)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.MixProject do
   def project do
     [
       app: :smart_city,
-      version: "3.2.0",
+      version: "3.2.1",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/smart_city/helpers_test.exs
+++ b/test/smart_city/helpers_test.exs
@@ -49,6 +49,10 @@ defmodule SmartCity.HelpersTest do
       assert "application/json" == Helpers.mime_type("json")
     end
 
+    test "recognizes upper-case mime types" do
+      assert "application/json" == Helpers.mime_type("JSON")
+    end
+
     test "passes through valid recognized mime types" do
       assert "text/csv" == Helpers.mime_type("text/csv")
     end


### PR DESCRIPTION
Covering bases on how we handle input formats
Probably unnecessary as the this should be handled by input validation but currently Reaper accepts upper-cased sourceFormats so this patch will maintain backward compatibility.