### PR TITLE
Remove old date validation logic

### DIFF
--- a/lib/smart_city/dataset.ex
+++ b/lib/smart_city/dataset.ex
@@ -103,36 +103,13 @@ defmodule SmartCity.Dataset do
         technical: Technical.new(tech)
       })
 
-    case return_errors(struct) do
-      [] -> {:ok, struct}
-      errors -> {:error, errors}
-    end
+    {:ok, struct}
   rescue
     e -> {:error, e}
   end
 
   defp create(msg) do
     {:error, "Invalid Dataset: #{inspect(msg)}"}
-  end
-
-  defp return_errors(struct) do
-    []
-    |> collect_errors(valid_modified_date?(struct.business.modifiedDate), %{
-      "business.modifiedDate" => "Not ISO8601 formatted"
-    })
-  end
-
-  defp valid_modified_date?(""), do: true
-
-  defp valid_modified_date?(date) do
-    case DateTime.from_iso8601(date) do
-      {:ok, _, _} -> true
-      {:error, _} -> false
-    end
-  end
-
-  defp collect_errors(list, condition, item_to_add) do
-    if condition == false, do: [item_to_add] ++ list, else: list
   end
 
   @doc """

--- a/test/smart_city/dataset_test.exs
+++ b/test/smart_city/dataset_test.exs
@@ -87,15 +87,6 @@ defmodule SmartCity.DatasetTest do
       assert technical.private == true
     end
 
-    test "returns an error when modifiedDate is not in the correct format", %{message: map} do
-      result =
-        map
-        |> put_in(["business", "modifiedDate"], "baddate")
-        |> Dataset.new()
-
-      assert {:error, [%{"business.modifiedDate" => "Not ISO8601 formatted"}]} == result
-    end
-
     test "returns properly if modifiedDate is blank", %{message: map} do
       result =
         map


### PR DESCRIPTION
This will be replaced with applications using SimplyVerify

smartcitiesdata/smartcitiesdata/smartcitiesdata#149

co-authored-by: Richard Jones <rajones@hntb.com>