### PR TITLE
less restrictive encoding

### DIFF
--- a/lib/smart_city/dataset.ex
+++ b/lib/smart_city/dataset.ex
@@ -70,7 +70,6 @@ defmodule SmartCity.Dataset do
           version: String.t()
         }
 
-  @derive Jason.Encoder
   defstruct version: "0.4", id: nil, business: nil, technical: nil
 
   use Accessible
@@ -140,6 +139,12 @@ defmodule SmartCity.Dataset do
   """
   def is_host?(%__MODULE__{technical: %{sourceType: sourceType}}) do
     "host" == sourceType
+  end
+end
+
+defimpl Jason.Encoder, for: [SmartCity.Dataset, SmartCity.Dataset.Technical, SmartCity.Dataset.Business] do
+  def encode(struct, opts) do
+    Jason.Encode.map(struct, opts)
   end
 end
 

--- a/lib/smart_city/dataset/business.ex
+++ b/lib/smart_city/dataset/business.ex
@@ -36,7 +36,6 @@ defmodule SmartCity.Dataset.Business do
           temporal: not_required()
         }
 
-  @derive Jason.Encoder
   defstruct authorEmail: nil,
             authorName: nil,
             categories: nil,

--- a/lib/smart_city/dataset/technical.ex
+++ b/lib/smart_city/dataset/technical.ex
@@ -27,7 +27,6 @@ defmodule SmartCity.Dataset.Technical do
           topLevelSelector: not_required(String.t())
         }
 
-  @derive Jason.Encoder
   defstruct allow_duplicates: true,
             authHeaders: %{},
             authUrl: nil,


### PR DESCRIPTION
This is part of the fix for https://github.com/smartcitiesdata/smartcitiesdata/issues/387

The other part, in reaper, will replace the term to bin of the dataset with a brook serialized version of it, and an MFA for a function we have more control over.

co-authored-by: Timothy Regan <tregan@pillartechnology.com>