### PR TITLE
No longer requiring modifiedDate in SmartCity.Dataset.Business

### DIFF
--- a/lib/smart_city/dataset/business.ex
+++ b/lib/smart_city/dataset/business.ex
@@ -92,7 +92,6 @@ defmodule SmartCity.Dataset.Business do
           contactName: _,
           dataTitle: _,
           description: _,
-          modifiedDate: _,
           orgTitle: _
         } = msg
       ) do
@@ -104,11 +103,14 @@ defmodule SmartCity.Dataset.Business do
     raise ArgumentError, "Invalid business metadata: #{inspect(msg)}"
   end
 
-  defp fix_modified_date(%{modifiedDate: nil} = business_map) do
-    Map.put(business_map, :modifiedDate, "")
+  defp fix_modified_date(business_map) do
+    business_map
+    |> Map.get_and_update(:modifiedDate, fn
+      nil -> {nil, ""}
+      current_value -> {current_value, current_value}
+    end)
+    |> elem(1)
   end
-
-  defp fix_modified_date(business_map), do: business_map
 
   defp create(map) do
     struct(%__MODULE__{}, map)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.MixProject do
   def project do
     [
       app: :smart_city,
-      version: "3.11.0",
+      version: "3.12.0",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/smart_city/dataset/business_test.exs
+++ b/test/smart_city/dataset/business_test.exs
@@ -64,10 +64,25 @@ defmodule SmartCity.Dataset.BusinessTest do
     test "throws error when creating Business struct without required fields", %{message: msg} do
       assert_raise ArgumentError, fn -> Business.new(msg |> Map.delete(:dataTitle)) end
       assert_raise ArgumentError, fn -> Business.new(msg |> Map.delete(:description)) end
-      assert_raise ArgumentError, fn -> Business.new(msg |> Map.delete(:modifiedDate)) end
       assert_raise ArgumentError, fn -> Business.new(msg |> Map.delete(:orgTitle)) end
       assert_raise ArgumentError, fn -> Business.new(msg |> Map.delete(:contactName)) end
       assert_raise ArgumentError, fn -> Business.new(msg |> Map.delete(:contactEmail)) end
+    end
+
+    test "defaults modified date to empty string when key is missing", %{message: biz} do
+      missing_date_map = Map.delete(biz, :modifiedDate)
+
+      actual = Business.new(missing_date_map)
+
+      assert actual.modifiedDate == ""
+    end
+
+    test "defaults modified date to empty string when provided value is nil", %{message: biz} do
+      nil_date_map = Map.put(biz, :modifiedDate, nil)
+
+      actual = Business.new(nil_date_map)
+
+      assert actual.modifiedDate == ""
     end
   end
 


### PR DESCRIPTION
no longer requiring modifiedDate in SmartCity.Dataset.Business, but still defaulting to an empty string when the value is not provided

smartcitiesdata/smartcitiesdata#328

co-authored-by: Jeff Grunewald <jeff@grunewalddesign.com>