### PR TITLE
Atomize schemas on new technical struct

### DIFF
--- a/lib/smart_city/dataset/technical.ex
+++ b/lib/smart_city/dataset/technical.ex
@@ -77,6 +77,13 @@ defmodule SmartCity.Dataset.Technical do
     |> new()
   end
 
+  def new(%{dataName: _, orgName: _, systemName: _, sourceUrl: _, sourceFormat: type, schema: schema} = msg) do
+    msg
+    |> Map.put(:schema, Helpers.to_atom_keys(schema))
+    |> Map.replace!(:sourceFormat, Helpers.mime_type(type))
+    |> create()
+  end
+
   def new(%{dataName: _, orgName: _, systemName: _, sourceUrl: _, sourceFormat: type} = msg) do
     mime_type = Helpers.mime_type(type)
 

--- a/lib/smart_city/helpers.ex
+++ b/lib/smart_city/helpers.ex
@@ -24,11 +24,8 @@ defmodule SmartCity.Helpers do
   @spec to_atom_keys(map()) :: map()
   def to_atom_keys(map) when is_map(map) do
     Map.new(map, fn
-      {key, val} when is_map(val) ->
+      {key, val} when is_map(val) or is_list(val) ->
         {safe_string_to_atom(key), to_atom_keys(val)}
-
-      {key, val} when is_list(val) ->
-        {safe_string_to_atom(key), Enum.map(val, &to_atom_keys/1)}
 
       {key, val} when is_binary(key) ->
         {safe_string_to_atom(key), val}

--- a/lib/smart_city/helpers.ex
+++ b/lib/smart_city/helpers.ex
@@ -25,20 +25,26 @@ defmodule SmartCity.Helpers do
   def to_atom_keys(map) when is_map(map) do
     Map.new(map, fn
       {key, val} when is_map(val) ->
-        {String.to_atom(key), to_atom_keys(val)}
+        {safe_string_to_atom(key), to_atom_keys(val)}
 
       {key, val} when is_list(val) ->
-        {String.to_atom(key), Enum.map(val, &to_atom_keys/1)}
+        {safe_string_to_atom(key), Enum.map(val, &to_atom_keys/1)}
 
       {key, val} when is_binary(key) ->
-        {String.to_atom(key), val}
+        {safe_string_to_atom(key), val}
 
       keyval ->
         keyval
     end)
   end
 
+  def to_atom_keys(list) when is_list(list), do: Enum.map(list, &to_atom_keys/1)
+
   def to_atom_keys(value), do: value
+
+  def safe_string_to_atom(string) when is_binary(string), do: String.to_atom(string)
+  def safe_string_to_atom(atom) when is_atom(atom), do: atom
+  def safe_string_to_atom(value), do: value
 
   @doc """
   Standardize file type definitions by deferring to the

--- a/test/smart_city/dataset/technical_test.exs
+++ b/test/smart_city/dataset/technical_test.exs
@@ -115,6 +115,32 @@ defmodule SmartCity.Dataset.TechnicalTest do
       assert actual.authHeaders.afoo == "abar"
     end
 
+    test "converts schema keys to atoms even when the top level is atoms", %{message: tech} do
+      actual =
+        Technical.new(%{
+          dataName: "dataset",
+          orgName: "org",
+          systemName: "org__dataset",
+          sourceUrl: "https://example.com",
+          sourceFormat: "gtfs",
+          schema: [
+            %{
+              "name" => "field_name",
+              "subSchema" => [
+                %{"name" => "deep"}
+              ]
+            }
+          ]
+        })
+
+      assert List.first(actual.schema) == %{
+               name: "field_name",
+               subSchema: [
+                 %{name: "deep"}
+               ]
+             }
+    end
+
     data_test "throws error when creating Technical struct without required field: #{field}", %{message: tech} do
       assert_raise ArgumentError, fn -> Technical.new(tech |> Map.delete(field)) end
 

--- a/test/smart_city/helpers_test.exs
+++ b/test/smart_city/helpers_test.exs
@@ -42,6 +42,21 @@ defmodule SmartCity.HelpersTest do
       input = %{foo: 1}
       assert Helpers.to_atom_keys(input) == input
     end
+
+    test "handles a map with atom keys that has nested string keys" do
+      input = %{foo: 1, bar: %{"baz" => "derp"}}
+      assert Helpers.to_atom_keys(input) == %{foo: 1, bar: %{baz: "derp"}}
+    end
+
+    test "handles a map with atom keys that has a list of objects with string keys" do
+      input = %{foo: 1, bar: [%{"baz" => "derp"}]}
+      assert Helpers.to_atom_keys(input) == %{foo: 1, bar: [%{baz: "derp"}]}
+    end
+
+    test "handles a list of maps with nested string keys" do
+      input = [%{foo: 1, bar: [%{"baz" => "derp"}]}]
+      assert Helpers.to_atom_keys(input) == [%{foo: 1, bar: [%{baz: "derp"}]}]
+    end
   end
 
   describe "mime_type/1" do


### PR DESCRIPTION
This ensures that dataset technical schemas always have atom keys. This will resolve the issue Valkyrie is facing:

```
15:34:28.855 [error] ** (FunctionClauseError) no function clause matching in anonymous fn/2 in Valkyrie.standardize_schema/2                                              │
│     (valkyrie) lib/valkyrie.ex:23: anonymous fn(%{"biased" => "No", "demographic" => "None", "description" => "Type of feature. vehicle positions is the only possible en │
│ try.", "masked" => "N/A", "name" => "type", "pii" => "None", "type" => "string"}, %{data: %{}, errors: %{}}) in Valkyrie.standardize_schema/2                             │
│     (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3                                                                                                        │
│     (valkyrie) lib/valkyrie.ex:13: Valkyrie.standardize_data/2                                                                                                            │
│     (valkyrie) lib/valkyrie/broadway.ex:89: Valkyrie.Broadway.standardize_data/2                                                                                          │
│     (valkyrie) lib/valkyrie/broadway.ex:62: Valkyrie.Broadway.handle_message/3                                                                                            │
│     (broadway) lib/broadway/processor.ex:66: Broadway.Processor.handle_messages/4                                                                                         │
│     (broadway) lib/broadway/processor.ex:36: Broadway.Processor.handle_events/3                                                                                           │
│     (gen_stage) lib/gen_stage.ex:2391: GenStage.consumer_dispatch/6
```